### PR TITLE
Removal of Use verb for grafana operator (3.6eus)

### DIFF
--- a/deploy/olm-catalog/ibm-monitoring-grafana-operator/1.10.5/ibm-monitoring-grafana-operator.v1.10.5.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-monitoring-grafana-operator/1.10.5/ibm-monitoring-grafana-operator.v1.10.5.clusterserviceversion.yaml
@@ -316,12 +316,6 @@ spec:
               - patch
               - delete
             - apiGroups:
-              - certmanager.k8s.io
-              resources:
-              - issuers
-              verbs:
-              - use
-            - apiGroups:
               - monitoringcontroller.cloud.ibm.com
               resources:
               - monitoringdashboards

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -69,12 +69,6 @@ metadata:
   name: ibm-monitoring-grafana-operator
 rules:
 - apiGroups:
-  - certmanager.k8s.io
-  resources:
-  - issuers
-  verbs:
-  - use
-- apiGroups:
   - ""
   resources:
   - pods


### PR DESCRIPTION
Removal of wrong verb `use` for the `issuers` type resource.
More details about the issue https://github.ibm.com/IBMPrivateCloud/roadmap/issues/44666#issuecomment-29578667