### PR TITLE
Upgrading the Grafana Server version for AquaScan vulnarabilities

### DIFF
--- a/deploy/olm-catalog/ibm-monitoring-grafana-operator/1.19.0/ibm-monitoring-grafana-operator.v1.19.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-monitoring-grafana-operator/1.19.0/ibm-monitoring-grafana-operator.v1.19.0.clusterserviceversion.yaml
@@ -130,7 +130,7 @@ metadata:
 spec:
   relatedImages:
     - name: GRAFANA_IMAGE
-      image: quay.io/opencloudio/grafana:v7.1.5-build.12
+      image: quay.io/opencloudio/grafana:v7.5.12-build.1
     - name: ICP_MANAGEMENT_INGRESS_IMAGE
       image: quay.io/opencloudio/icp-management-ingress:2.5.19
     - name: DASHBOARD_CONTROLLER_IMAGE
@@ -442,7 +442,7 @@ spec:
                       - name: OPERATOR_NAME
                         value: ibm-monitoring-grafana-operator
                       - name: GRAFANA_IMAGE
-                        value: quay.io/opencloudio/grafana:v7.1.5-build.12
+                        value: quay.io/opencloudio/grafana:v7.5.12-build.1
                       - name: ICP_MANAGEMENT_INGRESS_IMAGE
                         value: quay.io/opencloudio/icp-management-ingress:2.5.19
                       - name: DASHBOARD_CONTROLLER_IMAGE

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -82,7 +82,7 @@ spec:
             - name: OPERATOR_NAME
               value: ibm-monitoring-grafana-operator
             - name: GRAFANA_IMAGE
-              value: quay.io/opencloudio/grafana:v7.1.5-build.12
+              value: quay.io/opencloudio/grafana:v7.5.12-build.1
             - name: ICP_MANAGEMENT_INGRESS_IMAGE
               value: quay.io/opencloudio/icp-management-ingress:2.5.19
             - name: DASHBOARD_CONTROLLER_IMAGE


### PR DESCRIPTION
For Parent:
IBMPrivateCloud/roadmap#51607