### PR TITLE
Updating the GO version for Twistlock vulnarability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+# Copyright 2020 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#Always get the latest
+FROM golang:1.17.7 as builder
+ARG GOARCH
+
+WORKDIR /workspace
+
+
+COPY go.mod go.mod
+COPY go.sum go.sum
+
+COPY cmd cmd
+COPY common common
+COPY example example
+COPY pkg pkg
+COPY version version
+COPY Makefile Makefile
+
+RUN  go mod tidy \
+     && make build
+
+FROM hyc-cloud-private-edge-docker-local.artifactory.swg-devops.com/build-images/ubi8-minimal

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/IBM/ibm-monitoring-grafana-operator
 
-go 1.15
+go 1.17
 
 require (
 	github.com/jetstack/cert-manager v0.13.0

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,9 @@ module github.com/IBM/ibm-monitoring-grafana-operator
 go 1.17
 
 require (
+        github.com/ghodss/yaml v1.0.0
+	github.com/prometheus/prometheus v1.8.2-0.20200507164740-ecee9c8abfd1
+	gopkg.in/yaml.v2 v2.3.0 // indirect
 	github.com/jetstack/cert-manager v0.13.0
 	github.com/operator-framework/operator-sdk v0.18.0
 	sigs.k8s.io/controller-runtime v0.9.0


### PR DESCRIPTION
For Parent:
https://github.ibm.com/IBMPrivateCloud/roadmap/issues/51935

Vulnerabilities : CVE-2022-23772, CVE-2022-23806, CVE-2022-23773