### PR TITLE
bump version for CD 3.17.0-2

### DIFF
--- a/deploy/olm-catalog/ibm-monitoring-grafana-operator/1.21.0/ibm-monitoring-grafana-operator.v1.21.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-monitoring-grafana-operator/1.21.0/ibm-monitoring-grafana-operator.v1.21.0.clusterserviceversion.yaml
@@ -130,13 +130,13 @@ metadata:
 spec:
   relatedImages:
     - name: GRAFANA_IMAGE
-      image: quay.io/opencloudio/grafana:v7.1.5-build.12
+      image: quay.io/opencloudio/grafana:v7.1.5-build.14
     - name: ICP_MANAGEMENT_INGRESS_IMAGE
-      image: quay.io/opencloudio/icp-management-ingress:2.5.19
+      image: quay.io/opencloudio/icp-management-ingress:2.5.21
     - name: DASHBOARD_CONTROLLER_IMAGE
-      image: quay.io/opencloudio/dashboard-controller:v1.2.2-build.12
+      image: quay.io/opencloudio/dashboard-controller:v1.2.2-build.14
     - name: GRAFANA_OCPTHANOS_PROXY_IMAGE
-      image: quay.io/opencloudio/grafana-ocpthanos-proxy:1.0.13
+      image: quay.io/opencloudio/grafana-ocpthanos-proxy:1.0.15
     - name: ibm-monitoring-grafana-operator
       image: quay.io/opencloudio/ibm-monitoring-grafana-operator
   apiservicedefinitions: {}
@@ -442,13 +442,13 @@ spec:
                       - name: OPERATOR_NAME
                         value: ibm-monitoring-grafana-operator
                       - name: GRAFANA_IMAGE
-                        value: quay.io/opencloudio/grafana:v7.1.5-build.12
+                        value: quay.io/opencloudio/grafana:v7.1.5-build.14
                       - name: ICP_MANAGEMENT_INGRESS_IMAGE
-                        value: quay.io/opencloudio/icp-management-ingress:2.5.19
+                        value: quay.io/opencloudio/icp-management-ingress:2.5.21
                       - name: DASHBOARD_CONTROLLER_IMAGE
-                        value: quay.io/opencloudio/dashboard-controller:v1.2.2-build.12
+                        value: quay.io/opencloudio/dashboard-controller:v1.2.2-build.14
                       - name: GRAFANA_OCPTHANOS_PROXY_IMAGE
-                        value: quay.io/opencloudio/grafana-ocpthanos-proxy:1.0.13
+                        value: quay.io/opencloudio/grafana-ocpthanos-proxy:1.0.15
                     image: quay.io/opencloudio/ibm-monitoring-grafana-operator
                     imagePullPolicy: IfNotPresent
                     name: grafana


### PR DESCRIPTION
Correcting the operands version in the CVS. 
In addition to https://github.com/IBM/ibm-monitoring-grafana-operator/pull/156