### PR TITLE
Address CSVUsesConsistentImage rule

### DIFF
--- a/deploy/olm-catalog/ibm-monitoring-grafana-operator/1.22.0/ibm-monitoring-grafana-operator.v1.22.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-monitoring-grafana-operator/1.22.0/ibm-monitoring-grafana-operator.v1.22.0.clusterserviceversion.yaml
@@ -449,7 +449,7 @@ spec:
                         value: icr.io/cpopen/cpfs/dashboard-controller:v1.2.2-build.15
                       - name: GRAFANA_OCPTHANOS_PROXY_IMAGE
                         value: icr.io/cpopen/cpfs/grafana-ocpthanos-proxy:1.0.16
-                    image: icr.io/cpopen/ibm-monitoring-grafana-operator:1.22.0
+                    image: icr.io/cpopen/ibm-monitoring-grafana-operator
                     imagePullPolicy: IfNotPresent
                     name: grafana
                     securityContext:


### PR DESCRIPTION
CSVUsesConsistentImage is showing error with a few CVS including latest. 
The change here is to adhere to rule: https://github.ibm.com/IBMPrivateCloud/content-verification/blob/master/docs/rules/CSVUsesConsistentImage.md 
This was earlier fixed and somehow missed in 1.21.0 onwards